### PR TITLE
Add Claude desktop app to brew casks and dock for all machines except Lusha

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -18,6 +18,7 @@
       "amethyst"
       "bitwarden"
       "chromium"
+      "claude"
       {
         name = "coconutbattery";
         greedy = true;

--- a/machines/Ivans-Mac-mini/darwin/desktop/dock.nix
+++ b/machines/Ivans-Mac-mini/darwin/desktop/dock.nix
@@ -62,6 +62,7 @@ in
       { path = "/Applications/Chromium.app/"; }
       { path = "/Applications/Discord.app/"; }
       { path = "/Applications/Bitwarden.app/"; }
+      { path = "/Applications/Claude.app/"; }
       { path = "/Applications/Obsidian.app/"; }
 
       {

--- a/machines/Ivans-Mac-mini/darwin/desktop/homebrew.nix
+++ b/machines/Ivans-Mac-mini/darwin/desktop/homebrew.nix
@@ -17,6 +17,7 @@
       "amethyst"
       "bitwarden"
       "discord"
+      "claude"
       "chromium"
       "firefox"
       "ghostty"

--- a/machines/Ivans-MacBook-Air/darwin/dock.nix
+++ b/machines/Ivans-MacBook-Air/darwin/dock.nix
@@ -72,6 +72,7 @@ in
       { path = "/Applications/Obsidian.app/"; }
       { path = "/Applications/Bitwarden.app/"; }
       { path = "/Applications/Visual Studio Code.app/"; }
+      { path = "/Applications/Claude.app/"; }
       { path = "/Applications/coconutBattery.app/"; }
 
       {


### PR DESCRIPTION
- darwin/homebrew.nix: Add claude cask (applies to MacBook Pro and MacBook Air)
- Ivans-Mac-mini desktop: Add claude cask and dock entry
- Ivans-MacBook-Air dock: Add Claude.app (also used by MacBook Pro)
- Lusha work laptop left unchanged

https://claude.ai/code/session_01G3rsY9Z4fKAW7MUdujYNzB