### PR TITLE
notifications: add package, home module, and battery sub-feature

### DIFF
--- a/modules/home/notifications/default.nix
+++ b/modules/home/notifications/default.nix
@@ -1,0 +1,59 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.local.services.notifications;
+in
+{
+  options.local.services.notifications = {
+    battery = {
+      enable = mkEnableOption "periodic battery state notifications to Discord";
+
+      interval = mkOption {
+        type = types.int;
+        default = 30 * 60;
+        description = "Interval in seconds between battery notifications (default: 30 minutes)";
+      };
+
+      runAtLoad = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Send a notification immediately when the launchd job is loaded.";
+      };
+
+      discordWebhookFile = mkOption {
+        type = types.str;
+        description = "Path to file containing the Discord webhook URL.";
+      };
+    };
+  };
+
+  config = mkIf cfg.battery.enable {
+    local.launchd.services.notifications-battery = {
+      enable = true;
+      keepAlive = false;
+      inherit (cfg.battery) runAtLoad;
+      waitForSecrets = true;
+
+      command =
+        let
+          script = pkgs.writeShellScript "notifications-battery-run" ''
+            set -e
+            exec ${pkgs.notifications}/bin/notifications battery \
+              --webhook-file "${cfg.battery.discordWebhookFile}"
+          '';
+        in
+        "${script}";
+
+      extraServiceConfig = {
+        StartInterval = cfg.battery.interval;
+      };
+    };
+  };
+}

--- a/modules/home/notifications/default.nix
+++ b/modules/home/notifications/default.nix
@@ -12,29 +12,43 @@ let
 in
 {
   options.local.services.notifications = {
+    discordWebhookFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to a file containing a Discord webhook URL, shared by all
+        notification features that target Discord.
+      '';
+    };
+
     battery = {
-      enable = mkEnableOption "periodic battery state notifications to Discord";
+      enable = mkEnableOption "periodic battery state notifications";
 
       interval = mkOption {
         type = types.int;
         default = 30 * 60;
-        description = "Interval in seconds between battery notifications (default: 30 minutes)";
+        description = "Interval in seconds between battery notifications (default: 30 minutes).";
       };
 
       runAtLoad = mkOption {
         type = types.bool;
         default = false;
-        description = "Send a notification immediately when the launchd job is loaded.";
-      };
-
-      discordWebhookFile = mkOption {
-        type = types.path;
-        description = "Path to file containing the Discord webhook URL.";
+        description = "Send a battery notification immediately when the launchd job is loaded.";
       };
     };
   };
 
   config = mkIf cfg.battery.enable {
+    assertions = [
+      {
+        assertion = cfg.discordWebhookFile != null;
+        message = ''
+          local.services.notifications.battery.enable requires
+          local.services.notifications.discordWebhookFile to be set.
+        '';
+      }
+    ];
+
     local.launchd.services.notifications-battery = {
       enable = true;
       keepAlive = false;
@@ -46,7 +60,7 @@ in
           script = pkgs.writeShellScript "notifications-battery-run" ''
             set -e
             exec ${pkgs.notifications}/bin/notifications battery \
-              --webhook-file "${cfg.battery.discordWebhookFile}"
+              --webhook-file "${cfg.discordWebhookFile}"
           '';
         in
         "${script}";

--- a/modules/home/notifications/default.nix
+++ b/modules/home/notifications/default.nix
@@ -28,7 +28,7 @@ in
       };
 
       discordWebhookFile = mkOption {
-        type = types.str;
+        type = types.path;
         description = "Path to file containing the Discord webhook URL.";
       };
     };

--- a/packages/notifications/default.nix
+++ b/packages/notifications/default.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+let
+  src = ./.;
+  python = pkgs.python3.withPackages (ps: [ ps.click ]);
+in
+pkgs.writeShellScriptBin "notifications" ''
+  exec ${python}/bin/python ${src}/notifications.py "$@"
+''

--- a/packages/notifications/default.nix
+++ b/packages/notifications/default.nix
@@ -5,5 +5,6 @@ let
   python = pkgs.python3.withPackages (ps: [ ps.click ]);
 in
 pkgs.writeShellScriptBin "notifications" ''
+  export PATH="${pkgs.settings}/bin:$PATH"
   exec ${python}/bin/python ${src}/notifications.py "$@"
 ''

--- a/packages/notifications/notifications.py
+++ b/packages/notifications/notifications.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Send notifications to external channels.
+
+Subcommands:
+  battery   Send current battery state to a Discord webhook.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+import click
+
+
+def read_webhook(webhook: str | None, webhook_file: str | None) -> str | None:
+    if webhook:
+        return webhook.strip()
+    if webhook_file:
+        try:
+            with open(webhook_file) as fh:
+                return fh.read().strip()
+        except OSError as e:
+            click.echo(f"Could not read webhook file {webhook_file}: {e}", err=True)
+            return None
+    return None
+
+
+def send_discord(webhook_url: str, message: str, source: str) -> bool:
+    """Post a message to a Discord webhook. Returns True on success."""
+    hostname = platform.node()
+    payload = json.dumps({"content": f"**[{source}@{hostname}]** {message}"}).encode()
+    req = urllib.request.Request(
+        webhook_url,
+        data=payload,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "notifications/1.0",
+        },
+    )
+    try:
+        urllib.request.urlopen(req, timeout=10)
+        return True
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as e:
+        click.echo(f"Discord notification failed: {e}", err=True)
+        return False
+
+
+def get_battery_state() -> dict | None:
+    """Read battery state by shelling out to `settings battery --json`."""
+    try:
+        result = subprocess.run(
+            ["settings", "battery", "--json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        click.echo("`settings` CLI not found in PATH", err=True)
+        return None
+    except subprocess.CalledProcessError as e:
+        msg = (e.stderr or "").strip() or f"exit {e.returncode}"
+        click.echo(f"`settings battery --json` failed: {msg}", err=True)
+        return None
+
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        click.echo(f"Could not parse settings battery output: {e}", err=True)
+        return None
+
+
+def format_battery(info: dict) -> str:
+    parts = []
+    if info.get("percent") is not None:
+        parts.append(f"{info['percent']}%")
+    state = info.get("state")
+    if state and state != "unknown":
+        parts.append(state)
+    if info.get("time_remaining"):
+        parts.append(f"{info['time_remaining']} remaining")
+    if info.get("source"):
+        parts.append(f"on {info['source']}")
+    return ", ".join(parts) if parts else "unknown"
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def cli(ctx):
+    """Send notifications to external channels."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command()
+@click.option(
+    "--webhook",
+    envvar="NOTIFICATIONS_DISCORD_WEBHOOK",
+    help="Discord webhook URL (or set NOTIFICATIONS_DISCORD_WEBHOOK).",
+)
+@click.option(
+    "--webhook-file",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    help="Path to a file containing the Discord webhook URL.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print the message instead of sending it.",
+)
+def battery(webhook, webhook_file, dry_run):
+    """Send current battery state to a Discord webhook."""
+    info = get_battery_state()
+    if info is None:
+        sys.exit(1)
+
+    message = f"Battery: {format_battery(info)}"
+
+    if dry_run:
+        click.echo(message)
+        return
+
+    url = read_webhook(webhook, webhook_file)
+    if not url:
+        click.echo(
+            "No Discord webhook configured. Pass --webhook, --webhook-file, "
+            "or set NOTIFICATIONS_DISCORD_WEBHOOK.",
+            err=True,
+        )
+        sys.exit(1)
+
+    if not send_discord(url, message, source="notifications"):
+        sys.exit(1)
+    click.echo(f"Sent: {message}")
+
+
+if __name__ == "__main__":
+    cli(prog_name="notifications")
+    sys.exit(0)

--- a/packages/notifications/notifications.py
+++ b/packages/notifications/notifications.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Send notifications to external channels.
 
 Subcommands:
@@ -51,7 +50,11 @@ def send_discord(webhook_url: str, message: str, source: str) -> bool:
 
 
 def get_battery_state() -> dict | None:
-    """Read battery state by shelling out to `settings battery --json`."""
+    """Read battery state by shelling out to `settings battery --json`.
+
+    Returns the parsed dict, or None when the platform reports no battery
+    (e.g. desktop Macs). Raises RuntimeError on subprocess or parse failures.
+    """
     try:
         result = subprocess.run(
             ["settings", "battery", "--json"],
@@ -59,19 +62,16 @@ def get_battery_state() -> dict | None:
             text=True,
             check=True,
         )
-    except FileNotFoundError:
-        click.echo("`settings` CLI not found in PATH", err=True)
-        return None
+    except FileNotFoundError as e:
+        raise RuntimeError("`settings` CLI not found in PATH") from e
     except subprocess.CalledProcessError as e:
         msg = (e.stderr or "").strip() or f"exit {e.returncode}"
-        click.echo(f"`settings battery --json` failed: {msg}", err=True)
-        return None
+        raise RuntimeError(f"`settings battery --json` failed: {msg}") from e
 
     try:
         return json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        click.echo(f"Could not parse settings battery output: {e}", err=True)
-        return None
+        raise RuntimeError(f"Could not parse settings battery output: {e}") from e
 
 
 def format_battery(info: dict) -> str:
@@ -114,9 +114,15 @@ def cli(ctx):
 )
 def battery(webhook, webhook_file, dry_run):
     """Send current battery state to a Discord webhook."""
-    info = get_battery_state()
-    if info is None:
+    try:
+        info = get_battery_state()
+    except RuntimeError as e:
+        click.echo(str(e), err=True)
         sys.exit(1)
+
+    if info is None:
+        click.echo("No battery detected; nothing to notify.")
+        return
 
     message = f"Battery: {format_battery(info)}"
 
@@ -140,4 +146,3 @@ def battery(webhook, webhook_file, dry_run):
 
 if __name__ == "__main__":
     cli(prog_name="notifications")
-    sys.exit(0)

--- a/packages/settings/battery.py
+++ b/packages/settings/battery.py
@@ -51,11 +51,14 @@ def battery_get_macos() -> dict | None:
     state = "unknown"
     for f in fields:
         f_lc = f.lower()
-        if "charging" in f_lc and "not charging" not in f_lc:
-            state = "charging"
-            break
         if "discharging" in f_lc:
             state = "discharging"
+            break
+        if "not charging" in f_lc:
+            state = "ac"
+            break
+        if "charging" in f_lc:
+            state = "charging"
             break
         if "charged" in f_lc:
             state = "charged"
@@ -108,15 +111,16 @@ def battery_get_linux() -> dict | None:
 
     ac_online = None
     for ac in base.iterdir():
-        if ac.name.startswith(("AC", "ADP", "ACAD")):
-            online = (
-                (ac / "online").read_text().strip()
-                if (ac / "online").is_file()
-                else None
-            )
-            if online == "1":
-                ac_online = True
-                break
+        if not ac.name.startswith(("AC", "ADP", "ACAD")):
+            continue
+        online_path = ac / "online"
+        if not online_path.is_file():
+            continue
+        online = online_path.read_text().strip()
+        if online == "1":
+            ac_online = True
+            break
+        if ac_online is None:
             ac_online = False
 
     source = (
@@ -165,11 +169,12 @@ def register(cli):
             sys.exit(1)
 
         info = battery_get()
+        if as_json:
+            print(json.dumps(info))
+            return
+
         if info is None:
             print("No battery detected", file=sys.stderr)
             sys.exit(1)
 
-        if as_json:
-            print(json.dumps(info))
-        else:
-            print(f"Battery: {format_human(info)}")
+        print(f"Battery: {format_human(info)}")

--- a/packages/settings/battery.py
+++ b/packages/settings/battery.py
@@ -1,0 +1,175 @@
+"""Battery: Report battery state (macOS + Linux)."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from common import is_linux, is_macos
+
+
+def battery_get_macos() -> dict | None:
+    """Read battery state on macOS via pmset -g batt.
+
+    Returns dict with keys: percent (int), state (charging|discharging|charged|ac|unknown),
+    time_remaining (str or None), source (AC Power|Battery Power|None), present (bool).
+    Returns None if no internal battery is present (e.g. desktop Macs).
+    """
+    try:
+        result = subprocess.run(
+            ["pmset", "-g", "batt"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    out = result.stdout
+    if "InternalBattery" not in out:
+        return None
+
+    source_match = re.search(r"Now drawing from '([^']+)'", out)
+    source = source_match.group(1) if source_match else None
+
+    line_match = re.search(
+        r"InternalBattery-\S+\s*(?:\(id=\d+\))?\s*(.+)$", out, re.MULTILINE
+    )
+    if not line_match:
+        return None
+    rest = line_match.group(1)
+
+    percent_match = re.search(r"(\d+)%", rest)
+    percent = int(percent_match.group(1)) if percent_match else None
+
+    fields = [f.strip() for f in rest.split(";")]
+    state = "unknown"
+    for f in fields:
+        f_lc = f.lower()
+        if "charging" in f_lc and "not charging" not in f_lc:
+            state = "charging"
+            break
+        if "discharging" in f_lc:
+            state = "discharging"
+            break
+        if "charged" in f_lc:
+            state = "charged"
+            break
+        if "ac attached" in f_lc or f_lc == "finishing charge":
+            state = "ac"
+            break
+
+    time_match = re.search(r"(\d+:\d{2})\s*remaining", rest)
+    time_remaining = time_match.group(1) if time_match else None
+
+    return {
+        "percent": percent,
+        "state": state,
+        "time_remaining": time_remaining,
+        "source": source,
+        "present": True,
+    }
+
+
+def battery_get_linux() -> dict | None:
+    """Read battery state on Linux via /sys/class/power_supply/BAT*."""
+    base = Path("/sys/class/power_supply")
+    if not base.is_dir():
+        return None
+
+    bats = sorted(p for p in base.iterdir() if p.name.startswith("BAT"))
+    if not bats:
+        return None
+    bat = bats[0]
+
+    def read(name: str) -> str | None:
+        p = bat / name
+        if not p.is_file():
+            return None
+        try:
+            return p.read_text().strip()
+        except OSError:
+            return None
+
+    capacity = read("capacity")
+    status = (read("status") or "Unknown").lower()
+    state_map = {
+        "charging": "charging",
+        "discharging": "discharging",
+        "full": "charged",
+        "not charging": "ac",
+    }
+    state = state_map.get(status, "unknown")
+
+    ac_online = None
+    for ac in base.iterdir():
+        if ac.name.startswith(("AC", "ADP", "ACAD")):
+            online = (
+                (ac / "online").read_text().strip()
+                if (ac / "online").is_file()
+                else None
+            )
+            if online == "1":
+                ac_online = True
+                break
+            ac_online = False
+
+    source = (
+        "AC Power" if ac_online else ("Battery Power" if ac_online is False else None)
+    )
+
+    return {
+        "percent": int(capacity) if capacity and capacity.isdigit() else None,
+        "state": state,
+        "time_remaining": None,
+        "source": source,
+        "present": True,
+    }
+
+
+def battery_get() -> dict | None:
+    """Get current battery state, or None if no battery is present."""
+    if is_macos():
+        return battery_get_macos()
+    if is_linux():
+        return battery_get_linux()
+    return None
+
+
+def format_human(info: dict) -> str:
+    parts = []
+    if info.get("percent") is not None:
+        parts.append(f"{info['percent']}%")
+    state = info.get("state")
+    if state and state != "unknown":
+        parts.append(state)
+    if info.get("time_remaining"):
+        parts.append(f"{info['time_remaining']} remaining")
+    if info.get("source"):
+        parts.append(f"on {info['source']}")
+    return ", ".join(parts) if parts else "unknown"
+
+
+def register(cli):
+    @cli.command()
+    @click.option("--json", "as_json", is_flag=True, help="Output as JSON")
+    def battery(as_json):
+        """Show battery state (macOS + Linux)"""
+        if not is_macos() and not is_linux():
+            print("Battery info only available on macOS and Linux", file=sys.stderr)
+            sys.exit(1)
+
+        info = battery_get()
+        if info is None:
+            print("No battery detected", file=sys.stderr)
+            sys.exit(1)
+
+        if as_json:
+            print(json.dumps(info))
+        else:
+            print(f"Battery: {format_human(info)}")

--- a/packages/settings/common.py
+++ b/packages/settings/common.py
@@ -37,6 +37,8 @@ COMMAND_ALIASES = {
     "fd": "fulldiskaccess",
     "li": "login",
     "off": "poweroff",
+    "b": "battery",
+    "bat": "battery",
     "h": "help",
 }
 

--- a/packages/settings/settings.py
+++ b/packages/settings/settings.py
@@ -18,7 +18,6 @@ Subcommands:
   battery     Show battery state (macOS + Linux)
 """
 
-import sys
 
 import click
 
@@ -78,4 +77,3 @@ def help_cmd(ctx):
 
 if __name__ == "__main__":
     cli(prog_name="settings")
-    sys.exit(0)

--- a/packages/settings/settings.py
+++ b/packages/settings/settings.py
@@ -15,6 +15,7 @@ Subcommands:
   fulldiskaccess Manage Full Disk Access permissions (macOS only)
   login       List, add, or remove login items (macOS only)
   poweroff    Set volume and shutdown system (macOS + Linux)
+  battery     Show battery state (macOS + Linux)
 """
 
 import sys
@@ -27,6 +28,7 @@ import accessibility
 import appearance
 import autohide
 import awake
+import battery
 import dock
 import fulldiskaccess
 import location
@@ -53,6 +55,7 @@ accessibility.register(cli)
 appearance.register(cli)
 autohide.register(cli)
 awake.register(cli)
+battery.register(cli)
 dock.register(cli)
 fulldiskaccess.register(cli)
 location.register(cli)


### PR DESCRIPTION
Adds a new `notifications` package and home-manager service module whose only feature, for now, is sending the current battery state to a Discord webhook channel. Battery state is read via the existing `settings` CLI, which gains a new `battery` subcommand.

## Changes

- **`packages/settings`: add `battery` subcommand**
  - New `battery.py` reading state on macOS (`pmset -g batt`) and Linux (`/sys/class/power_supply`).
  - Reports percent, charge state, time remaining, and power source. Supports `--json` for machine consumption.
  - Wired into `settings.py` with `b` / `bat` aliases.

- **`packages/notifications`: new package**
  - New `notifications` CLI with a `battery` subcommand.
  - Reads state by shelling out to `settings battery --json`, then posts to a Discord webhook.
  - Webhook can be passed via `--webhook`, `--webhook-file`, or `NOTIFICATIONS_DISCORD_WEBHOOK`.
  - `--dry-run` prints the message instead of sending.

- **`modules/home/notifications`: launchd service module**
  - Exposes `local.services.notifications.{discordWebhookFile, battery.{enable, interval, runAtLoad}}`.
  - `discordWebhookFile` is shared at the `notifications` scope so future sub-features can reuse it; `battery` is just the first one.
  - Default interval: 30 minutes. Uses existing `local.launchd.services` to schedule periodic runs.
  - Not enabled on any machine yet — left for a follow-up wiring commit.

## Verification

- `nix-build` of both `settings` and `notifications` via the flake overlay succeeds on aarch64-darwin.
- `settings battery` → `Battery: 80%, ac, on AC Power`
- `settings battery --json` → `{"percent": 80, "state": "ac", "time_remaining": null, "source": "AC Power", "present": true}`
- `notifications battery --dry-run` (with `settings` on PATH) prints the formatted message.

## Follow-ups

- [ ] Add a new Discord channel for notifications and store its webhook in sops at `discord/webhooks/notifications` (or per-feature path like `discord/webhooks/notificationsBattery`).
- [ ] Declare `sops.secrets.discord-webhook-notifications` in `home/sops-secrets.nix`.
- [ ] Wire `local.services.notifications.{discordWebhookFile, battery.enable}` into a laptop machine (e.g. `machines/Lusha-Macbook-Ivan-Kovnatskyi/home/`).
- [ ] Possibly add a `--low-threshold` flag to only notify when discharging below N%.
