### PR TITLE
Add typos package to multiple machine configurations

### DIFF
--- a/machines/Ivans-Mac-mini/home/packages.nix
+++ b/machines/Ivans-Mac-mini/home/packages.nix
@@ -15,5 +15,6 @@
     music-export
     sesh
     treefmt
+    typos
   ];
 }

--- a/machines/Ivans-MacBook-Air/home/packages.nix
+++ b/machines/Ivans-MacBook-Air/home/packages.nix
@@ -11,5 +11,6 @@
       ]
     ))
     gh-repos-sync
+    typos
   ];
 }

--- a/machines/a3/home/desktop/packages.nix
+++ b/machines/a3/home/desktop/packages.nix
@@ -48,6 +48,7 @@ in
       rustc
       temperatures
       tmux-temperatures
+      typos
       typst
       typstyle
       uv


### PR DESCRIPTION
## Summary
This PR adds the `typos` package to the home package configurations across three machines.

## Changes
- Added `typos` to `machines/Ivans-Mac-mini/home/packages.nix`
- Added `typos` to `machines/Ivans-MacBook-Air/home/packages.nix`
- Added `typos` to `machines/a3/home/desktop/packages.nix`

## Details
The `typos` package is being installed as a development tool across multiple machine configurations. This appears to be a spell-checker or similar utility being added to the standard package set for these machines.

https://claude.ai/code/session_01UwCtCTDmT6VnntpXXQi1La