### PR TITLE
machines: remove Notes syncthing folder between a3 and mini

### DIFF
--- a/machines/Ivans-Mac-mini/home/server/syncthing-mgmt.nix
+++ b/machines/Ivans-Mac-mini/home/server/syncthing-mgmt.nix
@@ -32,17 +32,7 @@
     ];
 
     # Folders can reference devices by name (resolved from deviceDefinitionsFile)
-    folders = {
-      "Notes" = {
-        path = "${config.flags.externalStoragePath}/Notes";
-        label = "Notes";
-        devices = [
-          "Ivans-Mac-mini"
-          "Ivans-iPhone"
-          "a3"
-        ];
-      };
-    };
+    folders = { };
 
     restart = false;
   };

--- a/machines/a3/nixos/server/syncthing-mgmt.nix
+++ b/machines/a3/nixos/server/syncthing-mgmt.nix
@@ -37,17 +37,7 @@
     ];
 
     # Folders can reference devices by name (resolved from deviceDefinitionsFile)
-    folders = {
-      "Notes" = {
-        path = "${config.users.users.${username}.home}/Notes";
-        label = "Notes";
-        devices = [
-          "a3"
-          "Ivans-Mac-mini"
-          "Ivans-iPhone"
-        ];
-      };
-    };
+    folders = { };
 
     restart = false;
   };


### PR DESCRIPTION
## Summary

- Remove the `Notes` syncthing folder from a3 and Mac mini `syncthing-mgmt` configs, leaving `folders = { };`.

Notes now live in the iCloud Obsidian directory:
- Synced across Apple devices (iPhone, Mac mini, MacBooks) naturally via iCloud.
- Synced to the Linux box (a3) via the SyncTrain iOS app.

So the dedicated syncthing Notes folder is no longer needed.

## Test plan

- [ ] `nix flake check` / build a3 and mini configs
- [ ] Confirm syncthing no longer manages the `Notes` folder after deploy


---
_Generated by [Claude Code](https://claude.ai/code/session_015Wf6KZjvHuD6e7qEpbHDMF)_